### PR TITLE
Added the Africa August Course to the Website Outputs

### DIFF
--- a/assets/js/outputs.js
+++ b/assets/js/outputs.js
@@ -36,6 +36,15 @@ document.addEventListener('DOMContentLoaded', function() {
               'https://energystoragecoalition.eu/worskhop-on-methodology-for-flexibility-needs-assessments/',
           },
           {
+          category: ['media', 'research', 'software'],
+          title:
+            '<em>Modeling the Integration of Hydropower into Modern Energy Systems for Africa</em> Course, with Max Parzen and Martha Maria F. presenting the integration of hydropower into energy systems using PyPSA',
+          date: "2024-08-19",
+          author: 'International Centre for Hydropower',
+          source:
+            'https://ich.no/modeling-the-integration-of-hydropower-into-modern-energy-systems-for-africa/',
+          },
+          {
             category: ["media", "software"],
             title:
               'HiGHS Workshop 2024 - Max Parzen presents <em>The Role of Open-Source Solvers for Energy System Planning</em>',

--- a/assets/js/outputs.js
+++ b/assets/js/outputs.js
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', function() {
           {
           category: ['media', 'research', 'software'],
           title:
-            '<em>Modeling the Integration of Hydropower into Modern Energy Systems for Africa</em> Course, with Max Parzen and Martha Maria F. presenting the integration of hydropower into energy systems using PyPSA',
+            '<em>Modeling the Integration of Hydropower into Modern Energy Systems for Africa</em> Course, with Ekaterina Fedotova and Emmanuel Bolarinwa presenting the integration of hydropower into energy systems using PyPSA',
           date: "2024-08-19",
           author: 'International Centre for Hydropower',
           source:


### PR DESCRIPTION
* Added the *Modeling the Integration of Hydropower into Modern Energy Systems for Africa* Course, held in August this year, to the Website Outputs.
* Tried correcting the *Outputs* bug using ChatGPT code check, to no avail
   * This issue seems to be related to another file
   * The Chat GPT suggested replacing `parseInt` with `Number` - however, the ouput remained the same

![image](https://github.com/user-attachments/assets/47accf2c-a3ac-432c-ab15-3a388854b2b0)
